### PR TITLE
Fix login routes and auth redirects

### DIFF
--- a/apps/login/next-env.d.ts
+++ b/apps/login/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/login/src/app/api/auth/login/route.ts
+++ b/apps/login/src/app/api/auth/login/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+export const dynamic = 'force-dynamic';
+
 export function GET() {
   const backendUrl = process.env.BACKEND_URL;
 

--- a/apps/login/src/app/page.tsx
+++ b/apps/login/src/app/page.tsx
@@ -7,7 +7,7 @@ export default function LoginPage() {
 
   function handleSignIn() {
     setLoading(true);
-    window.location.href = "/api/auth/login";
+    window.location.href = "/login/api/auth/login";
   }
 
   return (

--- a/apps/traffic-dashboard/src/components/auth/AuthGate.tsx
+++ b/apps/traffic-dashboard/src/components/auth/AuthGate.tsx
@@ -22,7 +22,7 @@ export default function AuthGate({ children }: AuthGateProps) {
         });
 
         if (!response.ok) {
-          window.location.href = `${loginAppUrl}/api/auth/login`;
+          window.location.href = `${loginAppUrl}`;
           return;
         }
 
@@ -30,7 +30,7 @@ export default function AuthGate({ children }: AuthGateProps) {
           setStatus("ready");
         }
       } catch {
-        window.location.href = `${loginAppUrl}/api/auth/login`;
+        window.location.href = `${loginAppUrl}`;
       }
     }
 


### PR DESCRIPTION
Adjust imports and routing for the login app and update auth redirects. Changes:
- apps/login/next-env.d.ts: fix Next types import to use ".next/types/routes.d.ts".
- apps/login/src/app/api/auth/login/route.ts: mark the login API route as dynamic (export const dynamic = 'force-dynamic').
- apps/login/src/app/page.tsx: update sign-in redirect to use the login app base path ("/login/api/auth/login").
- apps/traffic-dashboard/src/components/auth/AuthGate.tsx: redirect unauthenticated users to the login app root (loginAppUrl) instead of directly calling the login API endpoint.

These changes correct pathing for a multi-app setup (login mounted at /login) and ensure the login API route behaves as a dynamic route to avoid caching issues.