### PR TITLE
Add /login basePath and standalone Docker

### DIFF
--- a/apps/login/next.config.ts
+++ b/apps/login/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  basePath: "/login",
 };
 
 export default nextConfig;

--- a/docker/Dockerfile.login
+++ b/docker/Dockerfile.login
@@ -20,12 +20,9 @@ ENV NODE_ENV=production
 ENV PORT=3003
 ENV BACKEND_URL=http://localhost:5000
 
-COPY apps/login/package*.json ./
-RUN npm ci --omit=dev
-
-COPY --from=builder /app/.next ./.next
-COPY --from=builder /app/next.config.ts ./next.config.ts
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
 
 EXPOSE 3003
 
-CMD ["npm", "start"]
+CMD ["node", "server.js"]


### PR DESCRIPTION
Set Next.js basePath to "/login" for the login app so it can be served under the /login route. Update Dockerfile to use the Next standalone output: copy the standalone and static artifacts from the builder and run the bundled server.js, removing the runtime npm install/ci and npm start steps. This reduces image size and runs the prebuilt standalone app.