### PR TITLE
Add Dockerfiles and enable Next standalone builds

### DIFF
--- a/apps/admin-dashboard/next.config.mjs
+++ b/apps/admin-dashboard/next.config.mjs
@@ -1,4 +1,7 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  output: "standalone",
+  basePath: "/admin",
+};
 
 export default nextConfig;

--- a/apps/public-app/next.config.ts
+++ b/apps/public-app/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;

--- a/apps/traffic-dashboard/next.config.ts
+++ b/apps/traffic-dashboard/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  basePath: "/control",
 };
 
 export default nextConfig;

--- a/docker/Dockerfile.admin-dashboard
+++ b/docker/Dockerfile.admin-dashboard
@@ -1,0 +1,24 @@
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY apps/admin-dashboard/package*.json ./
+RUN npm ci
+
+COPY apps/admin-dashboard/ ./
+
+RUN npm run build
+
+FROM node:22-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3001
+
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+
+EXPOSE 3001
+
+CMD ["node", "server.js"]

--- a/docker/Dockerfile.public-app
+++ b/docker/Dockerfile.public-app
@@ -1,0 +1,24 @@
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY apps/public-app/package*.json ./
+RUN npm ci
+
+COPY apps/public-app/ ./
+
+RUN npm run build
+
+FROM node:22-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3002
+
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+
+EXPOSE 3002
+
+CMD ["node", "server.js"]

--- a/docker/Dockerfile.traffic-dashboard
+++ b/docker/Dockerfile.traffic-dashboard
@@ -28,13 +28,10 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=3000
 
-COPY apps/traffic-dashboard/package*.json ./
-RUN npm ci --omit=dev
-
-COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/public ./public
-COPY --from=builder /app/next.config.ts ./next.config.ts
 
 EXPOSE 3000
 
-CMD ["npm", "start"]
+CMD ["node", "server.js"]


### PR DESCRIPTION
Enable Next.js standalone output and configure base paths for dashboards, and add per-app Dockerfiles for containerized production builds. Changes: set output: "standalone" in public-app and admin-dashboard next.config, add basePath "/admin" (admin) and "/control" (traffic). Add Dockerfile.admin-dashboard and Dockerfile.public-app that build and copy Next standalone artifacts and expose ports 3001/3002. Update docker/Dockerfile.traffic-dashboard to use the standalone output and static files and start via node server.js (expose port 3000). These changes produce smaller runtime images and standardize container startup for each app.