### PR TITLE
Use npm install in admin dashboard Dockerfile

### DIFF
--- a/docker/Dockerfile.admin-dashboard
+++ b/docker/Dockerfile.admin-dashboard
@@ -3,7 +3,7 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 
 COPY apps/admin-dashboard/package*.json ./
-RUN npm ci
+RUN npm install
 
 COPY apps/admin-dashboard/ ./
 


### PR DESCRIPTION
Replace `npm ci` with `npm install` in docker/Dockerfile.admin-dashboard. This changes the Docker build to use the standard npm installer during image build, which can be required when a lockfile is missing or when installing packages on the Alpine-based image.