### PR TITLE
Fix/auth basepath

### DIFF
--- a/apps/admin-dashboard/src/components/auth/AuthGate.tsx
+++ b/apps/admin-dashboard/src/components/auth/AuthGate.tsx
@@ -22,7 +22,7 @@ export default function AuthGate({ children }: AuthGateProps) {
         });
 
         if (!response.ok) {
-          window.location.href = `${loginAppUrl}/api/auth/login`;
+          window.location.href = `${loginAppUrl}/login/api/auth/login`;
           return;
         }
 
@@ -30,7 +30,7 @@ export default function AuthGate({ children }: AuthGateProps) {
           setStatus("ready");
         }
       } catch {
-        window.location.href = `${loginAppUrl}/api/auth/login`;
+        window.location.href = `${loginAppUrl}/login/api/auth/login`;
       }
     }
 

--- a/docker/Dockerfile.admin-dashboard
+++ b/docker/Dockerfile.admin-dashboard
@@ -3,7 +3,7 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 
 COPY apps/admin-dashboard/package*.json ./
-RUN npm ci
+RUN npm install
 
 COPY apps/admin-dashboard/ ./
 


### PR DESCRIPTION
Updated AuthGate component to redirect to /login/api/auth/login instead of /api/auth/login
Login app has basePath: /login configured in next.config.ts, so all routes must be prefixed