### PR TITLE
Add NEXT_PUBLIC env args to admin Dockerfile

### DIFF
--- a/docker/Dockerfile.admin-dashboard
+++ b/docker/Dockerfile.admin-dashboard
@@ -7,6 +7,12 @@ RUN npm install
 
 COPY apps/admin-dashboard/ ./
 
+ARG NEXT_PUBLIC_BACKEND_URL=http://localhost:5000
+ARG NEXT_PUBLIC_LOGIN_APP_URL=http://localhost:3003
+
+ENV NEXT_PUBLIC_BACKEND_URL=$NEXT_PUBLIC_BACKEND_URL
+ENV NEXT_PUBLIC_LOGIN_APP_URL=$NEXT_PUBLIC_LOGIN_APP_URL
+
 RUN npm run build
 
 FROM node:22-alpine AS runner


### PR DESCRIPTION
Introduce build ARGs NEXT_PUBLIC_BACKEND_URL and NEXT_PUBLIC_LOGIN_APP_URL with localhost defaults, and expose them as ENV variables in docker/Dockerfile.admin-dashboard. This allows overriding the backend and login app URLs at build time (via --build-arg) so the admin dashboard can be configured for different environments.