### PR TITLE
fix: redirect to Keycloak logout Url in traffic dashboard

### DIFF
--- a/apps/traffic-dashboard/src/components/layout/SideNavBar.tsx
+++ b/apps/traffic-dashboard/src/components/layout/SideNavBar.tsx
@@ -23,10 +23,19 @@ export default function SideNavBar() {
     }
 
     try {
-      await fetch(`${backendUrl}/api/auth/logout`, {
+      const response = await fetch(`${backendUrl}/api/auth/logout`, {
         method: "POST",
         credentials: "include",
       });
+
+      if (response.ok) {
+        const data = await response.json();
+        if (data.logoutUrl) {
+          window.location.href = data.logoutUrl;
+          return;
+        }
+      }
+
       window.location.href = loginAppUrl;
     } catch (err) {
       console.error("Logout error", err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "b3-dashboard",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Ensure logout redirects to backend-provided Keycloak end-session URL so SSO requires re-auth.